### PR TITLE
Update dependencies in requirements.txt, specifying webcolors 1.13 & adding BoxAgent.xml to xml_objects directory & edited README

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ This script uses the default values within the package:
 random_seed=None
 config_path="examples/config_files/complex-config.yml"
 xml_dir="examples/xml_objects"
-export_path="export/test"
+export_path="export"
 ```
 
 ## 3) Designing the configuration file 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ dm_control  # handles mujoco/mjcfs
 shapely  # for collision detection
 matplotlib  # for plotting
 sphinx  # for documentation
-webcolors
+webcolors==1.13 # Locked at 1.13 for hex-to-name color mapping compatibility.
 pillow
 typer
 sphinx_rtd_theme

--- a/src/pitapy/examples/xml_objects/BoxAgent.xml
+++ b/src/pitapy/examples/xml_objects/BoxAgent.xml
@@ -1,0 +1,8 @@
+<mujoco model="boxagent">
+    <worldbody>       
+        <body pos="0.0 0.0 0.5" name="boxagent">
+            <joint type="free" name="boxagent_freeJoint" />
+            <geom type="box" size="0.5 0.5 0.5" euler="0 0 0" rgba=".949 .7451 .1333 1" name="boxagent_geom" />
+        </body>
+    </worldbody>
+</mujoco>


### PR DESCRIPTION
1. The webcolors package needs to be specified due to the following error:

`AttributeError: module 'webcolors' has no attribute 'CSS3_HEX_TO_NAMES'`

This error occurs when trying to retrieve a dictionary that maps normalized hexadecimal values of the sixteen named HTML 4 colors to their corresponding normalized names.

2. The BoxAgent.xml file is required for the simple-config.yml in the config_files directory to function properly.